### PR TITLE
test: fix failing test

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
 junit_family=legacy
+asyncio_default_fixture_loop_scope = function
 filterwarnings =
     error
     ignore::pytest.PytestUnraisableExceptionWarning
+    ignore::pytest.PytestDeprecationWarning

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -15,7 +15,9 @@ def get_code_blocks(file_path):
     with file_path.open() as file_handle:
         content = file_handle.read()
 
-    code_blocks = publish_doctree(content).findall(condition=is_code_block)
+    code_blocks = publish_doctree(
+        content, settings_overrides={"report_level": 5}
+    ).findall(condition=is_code_block)
     return [block.astext() for block in code_blocks]
 
 


### PR DESCRIPTION
- ignore `PytestDeprecationWarning` in `pytest.ini`.

- suppress `docutils` errors in `tests/test_examples.py` by setting `report_level` to 5.